### PR TITLE
Configure Vercel static output

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,5 @@
+node_modules
+.DS_Store
+server/public
+vite.config.ts.*
+*.tar.gz

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist/public"
+}


### PR DESCRIPTION
## Summary
- Add `vercel.json` to deploy client build from `dist/public`
- Provide `.vercelignore` so Vercel keeps the built client output

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b106f086b48325891e98e4ef7bfc43