### PR TITLE
Fix static path for Vercel deployment

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -6,6 +6,7 @@ var __export = (target, all) => {
 
 // server/index.ts
 import express2 from "express";
+import serverless from "serverless-http";
 
 // server/routes.ts
 import { createServer } from "http";
@@ -530,7 +531,12 @@ async function setupVite(app2, server) {
   });
 }
 function serveStatic(app2) {
-  const distPath = path2.resolve(import.meta.dirname, "public");
+  const distPath = path2.resolve(
+    import.meta.dirname,
+    "..",
+    "dist",
+    "public"
+  );
   if (!fs.existsSync(distPath)) {
     throw new Error(
       `Could not find the build directory: ${distPath}, make sure to build the client first`
@@ -543,7 +549,6 @@ function serveStatic(app2) {
 }
 
 // server/index.ts
-import { fileURLToPath } from "url";
 var app = express2();
 app.use(express2.json());
 app.use(express2.urlencoded({ extended: false }));
@@ -571,10 +576,7 @@ app.use((req, res, next) => {
   });
   next();
 });
-var handler = app;
-var index_default = app;
-var isDirectRun = process.argv[1] === fileURLToPath(import.meta.url);
-async function init() {
+(async () => {
   const server = await registerRoutes(app);
   app.use((err, _req, res, _next) => {
     const status = err.status || err.statusCode || 500;
@@ -584,22 +586,14 @@ async function init() {
   });
   if (app.get("env") === "development") {
     await setupVite(app, server);
-  } else {
+  } else if (!process.env.VERCEL) {
     serveStatic(app);
   }
-  if (isDirectRun) {
-    const port = parseInt(process.env.PORT || "5000", 10);
-    server.listen({
-      port,
-      host: "0.0.0.0",
-      reusePort: true
-    }, () => {
-      log(`serving on port ${port}`);
-    });
-  }
-}
-void init();
+})();
+var handler = serverless(app);
+var index_default = app;
 export {
+  app,
   index_default as default,
   handler
 };

--- a/server/index.ts
+++ b/server/index.ts
@@ -56,7 +56,7 @@ app.use((req, res, next) => {
   // doesn't interfere with the other routes
   if (app.get("env") === "development") {
     await setupVite(app, server);
-  } else {
+  } else if (!process.env.VERCEL) {
     serveStatic(app);
   }
 

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -68,7 +68,12 @@ export async function setupVite(app: Express, server: Server) {
 }
 
 export function serveStatic(app: Express) {
-  const distPath = path.resolve(import.meta.dirname, "public");
+  const distPath = path.resolve(
+    import.meta.dirname,
+    "..",
+    "dist",
+    "public",
+  );
 
   if (!fs.existsSync(distPath)) {
     throw new Error(


### PR DESCRIPTION
## Summary
- Skip static asset serving in serverless environment
- Resolve static files from dist/public when running locally

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1060569f08325ba2d7a9ea8f81a70